### PR TITLE
Add op_status

### DIFF
--- a/pyfujitseu/splitAC.py
+++ b/pyfujitseu/splitAC.py
@@ -383,11 +383,11 @@ class splitAC:
 
     @property
     def op_status(self):
-        return self._get_prop_from_json('op_status', self._properties)
+        return self._get_prop_from_json("op_status", self._properties)
     
     def get_op_status_desc(self):
         DICT_OP_MODE = {
-            0: 'Normal',
+            0: "Normal",
             16777216: "Defrost"
         }
         status = self.op_status["value"]

--- a/pyfujitseu/splitAC.py
+++ b/pyfujitseu/splitAC.py
@@ -360,7 +360,7 @@ class splitAC:
         
     @property
     def op_status(self):
-        return self._get_prop_from_json('op_status',self._properties)
+        return self._get_prop_from_json('op_status', self._properties)
     
     def get_op_status_desc(self):
         DICT_OP_MODE = {
@@ -368,7 +368,7 @@ class splitAC:
             16777216: "Defrost"
         }
         status = self.op_status["value"]
-        return DICT_OP_MODE[status] if status in DICT_OP_MODE else f"Unknown {status}"
+        return DICT_OP_MODE[status] if status in DICT_OP_MODE else f"Unknown: {status}"
         
     ## Get a property history
     def _get_device_property_history(self,propertyCode):

--- a/pyfujitseu/splitAC.py
+++ b/pyfujitseu/splitAC.py
@@ -358,6 +358,18 @@ class splitAC:
     def device_name(self,properties):
         self._device_name = self._get_prop_from_json('device_name',properties)
         
+    @property
+    def op_status(self):
+        return self._get_prop_from_json('op_status',self._properties)
+    
+    def get_op_status_desc(self):
+        DICT_OP_MODE = {
+            0: 'Normal',
+            16777216: "Defrost"
+        }
+        status = self.op_status["value"]
+        return DICT_OP_MODE[status] if status in DICT_OP_MODE else f"Unknown {status}"
+        
     ## Get a property history
     def _get_device_property_history(self,propertyCode):
         propertyHistory = self._api._get_device_property(propertyCode)


### PR DESCRIPTION
Adds the 'op_status' from the API. Currently only 'Normal' and 'Defrost' states are decoded.
See page 21 of [FGLair manual](https://www.fujitsugeneral.com/us/resources/pdf/residential/benefits/9384296009-02_OM_EN_D1_.pdf
)
```
{
      "property":{
         "type":"Property",
         "name":"op_status",
         "base_type":"integer",
         "read_only":true,
         "direction":"output",
         "scope":"user",
         "data_updated_at":"2022-12-18T17:23:01Z",
         "key":72788042,
         "device_key":668_XXX_,
         "product_name":"AC000W00_XXXXXXX_",
         "track_only_changes":false,
         "display_name":"op_status",
         "host_sw_version":false,
         "time_series":false,
         "derived":false,
         "app_type":"None",
         "recipe":"None",
         "value":16777216,
         "generated_from":"AYLA::device",
         "generated_at":"None",
         "denied_roles":[
            
         ],
         "ack_enabled":false,
         "retention_days":30,
         "ack_status":"None",
         "ack_message":"None",
         "acked_at":"None"
      }
   }
```