### PR TITLE
default to auto

### DIFF
--- a/pyfujitsugeneral/splitAC.py
+++ b/pyfujitsugeneral/splitAC.py
@@ -19,6 +19,8 @@ _LOGGER = logging.getLogger(__name__)
 
 def get_prop_from_json(property_name: str, properties: Any) -> dict[str, Any]:
     for property_item in properties:
+        if not isinstance(property_item, dict)
+            return {}
         if property_item["property"]["name"] == property_name:
             if property_name == "refresh":
                 return {

--- a/pyfujitsugeneral/splitAC.py
+++ b/pyfujitsugeneral/splitAC.py
@@ -98,7 +98,7 @@ class SplitAC:
         datapoints = await self._async_get_device_property_history(
             self.get_operation_mode()["key"]
         )
-        last_operation_mode = 0
+        last_operation_mode = self._operation_mode_translate("auto")
         for datapoint in reversed(datapoints):
             if datapoint["datapoint"]["value"] != 0:
                 last_operation_mode = int(datapoint["datapoint"]["value"])


### PR DESCRIPTION
Hi @bigmoby, if the heatpump does not provide op mode history then it will not turn on as mode is set to 0. This PR changes default action to "auto" which will still allow the unit to turn on if there is no operation history returned.

Avoid error where a str is returned rather than a dict
```
File "/usr/local/lib/python3.12/site-packages/pyfujitsugeneral/splitAC.py", line 22, in get_prop_from_json
if property_item["property"]["name"] == property_name:
~~~~~~~~~~~~~^^^^^^^^^^^^
TypeError: string indices must be integers, not 'str'
```